### PR TITLE
Remove cluster domain name to support non-REC systems

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -15,22 +15,27 @@ data:
     }
     http {
       access_log /dev/null;
+{{ if .Values.service.elasticsearch_external_port }}
       server {
         listen 9200 ssl;
         ssl_certificate_key  /certs/tls.key;
         ssl_certificate      /certs/tls.crt;
         location / {
-          proxy_pass http://elasticsearch-logging.kube-system.svc.rec.io:9200;
+          proxy_pass http://elasticsearch-logging.kube-system:9200;
         }
       }
+{{ end }}
+{{ if .Values.service.prometheus_external_port }}
       server {
         listen 9090 ssl;
         ssl_certificate_key  /certs/tls.key;
         ssl_certificate      /certs/tls.crt;
         location / {
-          proxy_pass https://prometheus.kube-system.svc.rec.io:9090;
+          proxy_pass https://prometheus.kube-system:9090;
         }
       }
+{{ end }}
+{{ if .Values.service.kubeapi_external_port }}
       server {
         listen 6443 ssl;
         ssl_certificate_key  /certs/tls.key;
@@ -39,4 +44,5 @@ data:
           proxy_pass http://localhost:80;
         }
       }
+{{ end }}
     }


### PR DESCRIPTION
Currently "rec.io" cluster domain name is hardcoded in the nginx config.
Theoretically all the Kubernetes Pods should be able to resolve `<servicename>.<namespace>` naming, so we can simply drop the product specific cluster domain name from the FQDN we use internally.

Fixes #10 